### PR TITLE
Remove project dependency to CodeGeneration and post build event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,13 @@ jobs:
           dotnet-version: 6.0.x
       - name: Restore
         run: dotnet restore
-      - name: Run code generation
+      - name: Build code generation
         run: dotnet build src/CodeGeneration/CodeGeneration.csproj -c Release --no-restore
-      - name: Build
+      - name: Run code generation
+        run: dotnet src/CodeGeneration/bin/Release/net6.0/CodeGeneration.dll
+      - name: Build solution
         run: dotnet build -c Release --no-restore
-      - name: Test
+      - name: Run tests
         run: dotnet test -c Release
       #- name: Pack
       #  if: matrix.os == 'ubuntu-latest'
@@ -78,6 +80,8 @@ jobs:
           echo Version: $VERSION
           VERSION="${VERSION//v}"
           echo Clean Version: $VERSION
+          dotnet build src/CodeGeneration/CodeGeneration.csproj -c Release
+          dotnet src/CodeGeneration/bin/Release/net6.0/CodeGeneration.dll
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -p:Version=$VERSION -o nupkg
       - name: Push to GitHub Feed
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,8 +17,10 @@ jobs:
           dotnet-version: 6.0.x
       - name: Restore
         run: dotnet restore
-      - name: Run code generation
+      - name: Build code generation
         run: dotnet build src/CodeGeneration/CodeGeneration.csproj -c Release --no-restore
+      - name: Run code generation
+        run: dotnet src/CodeGeneration/bin/Release/net6.0/CodeGeneration.dll
       - name: sonarscan-dotnet
         uses: highbyte/sonarscan-dotnet@v2.1.2
         with:

--- a/DialogFramework.sln
+++ b/DialogFramework.sln
@@ -6,9 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogFramework.Abstractions", "src\DialogFramework.Abstractions\DialogFramework.Abstractions.csproj", "{F3D6A62A-D77F-4063-9F8D-D70F1C4264E1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogFramework.Domain", "src\DialogFramework.Domain\DialogFramework.Domain.csproj", "{D37F5A3B-976D-4FF3-B18D-A719AF29CF91}"
-	ProjectSection(ProjectDependencies) = postProject
-		{DBCEA97F-BE1E-4152-8BD5-910CA28466F8} = {DBCEA97F-BE1E-4152-8BD5-910CA28466F8}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DialogFramework.Domain.Tests", "src\DialogFramework.Domain.Tests\DialogFramework.Domain.Tests.csproj", "{1CECF992-6EF9-43CB-9792-3F310A67BCD0}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ dialog = sut.Continue
 
 See unit tests for more examples.
 
+# Getting local environment up and running
+
+To build the solution on your development machine, you first need to build and run the CodeGeneration project. This is because I have decided not to commit generated code to the Git repository.
+
+To do this, simply set the CodeGeneration project as start up project in Visual Studio, and hit F5.
+Or, alternatively, use dotnet from the command line to run it.
+dotnet src/CodeGeneration/bin/Release/net6.0/CodeGeneration.dll
+
 # Project structure
 
 The solution consists of the following projects:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ See unit tests for more examples.
 To build the solution on your development machine, you first need to build and run the CodeGeneration project. This is because I have decided not to commit generated code to the Git repository.
 
 To do this, simply set the CodeGeneration project as start up project in Visual Studio, and hit F5.
-Or, alternatively, use dotnet from the command line to run it.
-dotnet src/CodeGeneration/bin/Release/net6.0/CodeGeneration.dll
+Or, alternatively, use dotnet from the command line to build and run it.
+e.g.
+dotnet build src/CodeGeneration/CodeGeneration.csproj
+dotnet src/CodeGeneration/bin/Debug/net6.0/CodeGeneration.dll
 
 # Project structure
 

--- a/src/CodeGeneration/CodeGeneration.csproj
+++ b/src/CodeGeneration/CodeGeneration.csproj
@@ -20,8 +20,4 @@
     <ProjectReference Include="..\DialogFramework.Abstractions\DialogFramework.Abstractions.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="dotnet $(TargetDir)CodeGeneration.dll" />
-  </Target>
-
 </Project>

--- a/src/CodeGeneration/Program.cs
+++ b/src/CodeGeneration/Program.cs
@@ -6,7 +6,10 @@ internal static class Program
     private static void Main(string[] args)
     {
         // Setup code generation
-        var basePath = Path.Combine(Directory.GetCurrentDirectory(), @"../");
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var basePath = currentDirectory == "/home/runner/work/DialogFramework/DialogFramework"
+            ? Path.Combine(currentDirectory, @"src/")
+            : Path.Combine(currentDirectory, @"../../../../");
         var generateMultipleFiles = true;
         var dryRun = false;
         var multipleContentBuilder = new MultipleContentBuilder { BasePath = basePath };


### PR DESCRIPTION
Removed project dependency to CodeGeneration, and post-build event to run code generation. This is now a manual step in the build pipeline.

This may sound less automated, but it's more obvious how it works now. The build pipeline didn't work automatically, anyway. Now you have to perform a manual step on your local environment also.