### PR TITLE
Decision and navigation part refactor

### DIFF
--- a/.sonarlint/DialogFramework.slconfig
+++ b/.sonarlint/DialogFramework.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AXhZfo6en_M4LyoxHL-X",
-      "ProfileTimestamp": "2022-03-31T10:15:41Z"
+      "ProfileTimestamp": "2022-07-05T10:19:10Z"
     }
   }
 }

--- a/.sonarlint/pauldeen79_dialogframeworkcsharp.ruleset
+++ b/.sonarlint/pauldeen79_dialogframeworkcsharp.ruleset
@@ -362,6 +362,12 @@
     <Rule Id="S5659" Action="Warning" />
     <Rule Id="S5773" Action="Warning" />
     <Rule Id="S6354" Action="None" />
+    <Rule Id="S6419" Action="Warning" />
+    <Rule Id="S6420" Action="Warning" />
+    <Rule Id="S6421" Action="None" />
+    <Rule Id="S6422" Action="Warning" />
+    <Rule Id="S6423" Action="None" />
+    <Rule Id="S6424" Action="Warning" />
     <Rule Id="S818" Action="Info" />
     <Rule Id="S881" Action="None" />
     <Rule Id="S907" Action="Warning" />

--- a/README.md
+++ b/README.md
@@ -74,6 +74,5 @@ The solution consists of the following projects:
 # TODOs
 
 - Allow interception from outside the dialog and dialogparts, through the AfterNavigate and BeforeNavigate methods
-- Try to refactor INavigationDialogPart and IDecisionDialogPart to use BeforeNavigate to accomplish this
 - Try to move interfaces from Abstractions to CodeGeneration, and remove references to Abstractions project. Use Domain implementations in signatures instead (inclusing enums, which need to be generated from Abstractions/CodeGeneration).
 - Create a minimal web api as a demo project, using some sort of state store (local in-memory cache?) for persisting state.

--- a/src/DialogFramework.Abstractions/DialogParts/IDecisionDialogPart.cs
+++ b/src/DialogFramework.Abstractions/DialogParts/IDecisionDialogPart.cs
@@ -2,7 +2,4 @@
 
 public interface IDecisionDialogPart : IDialogPart
 {
-    Result<IDialogPartIdentifier> GetNextPartId(IDialog dialog,
-                                                IDialogDefinition dialogDefinition,
-                                                IConditionEvaluator conditionEvaluator);
 }

--- a/src/DialogFramework.Abstractions/DialogParts/INavigationDialogPart.cs
+++ b/src/DialogFramework.Abstractions/DialogParts/INavigationDialogPart.cs
@@ -2,5 +2,4 @@
 
 public interface INavigationDialogPart : IDialogPart
 {
-    IDialogPartIdentifier GetNextPartId(IDialog dialog);
 }

--- a/src/DialogFramework.Abstractions/IDialogDefinition.cs
+++ b/src/DialogFramework.Abstractions/IDialogDefinition.cs
@@ -20,12 +20,9 @@ public interface IDialogDefinition
                          IDialogPartIdentifier navigateToPartId,
                          IEnumerable<IDialogPartResult> existingPartResults);
 
-    Result<IDialogPart> GetFirstPart(IDialog dialog,
-                                     IConditionEvaluator evaluator);
+    Result<IDialogPart> GetFirstPart();
 
-    Result<IDialogPart> GetNextPart(IDialog dialog,
-                                    IConditionEvaluator evaluator,
-                                    IEnumerable<IDialogPartResultAnswer> results);
+    Result<IDialogPart> GetNextPart(IDialog dialog, IEnumerable<IDialogPartResultAnswer> results);
 
     Result<IDialogPart> GetPartById(IDialogPartIdentifier id);
 }

--- a/src/DialogFramework.Abstractions/IDialogPart.cs
+++ b/src/DialogFramework.Abstractions/IDialogPart.cs
@@ -6,6 +6,6 @@ public interface IDialogPart
     DialogState GetState();
     IDialogPartBuilder CreateBuilder();
     bool SupportsReset();
-    void BeforeNavigate(IBeforeNavigateArguments args);
-    void AfterNavigate(IAfterNavigateArguments args);
+    Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args);
+    Result<IDialogPart>? AfterNavigate(IAfterNavigateArguments args);
 }

--- a/src/DialogFramework.Abstractions/INavigateArguments.cs
+++ b/src/DialogFramework.Abstractions/INavigateArguments.cs
@@ -3,17 +3,15 @@
 public interface INavigateArguments
 {
     IDialogIdentifier CurrentDialogId { get; }
-    IDialogDefinitionIdentifier CurrentDialogIdentifier { get; set; }
-    IDialogPartIdentifier CurrentPartId { get; set; }
-    IDialogPartGroupIdentifier? CurrentGroupId { get; set; }
-    DialogState CurrentState { get; set; }
-    string? ErrorMessage { get; set; }
-    Result? Result { get; set; }
+    IDialogDefinitionIdentifier CurrentDialogIdentifier { get; }
+    IDialogPartIdentifier CurrentPartId { get; }
+    IDialogPartGroupIdentifier? CurrentGroupId { get; }
+    DialogState CurrentState { get; }
+    string? ErrorMessage { get;  }
 
     DialogAction Action { get; }
     IDialogDefinition DialogDefinition { get; }
     IConditionEvaluator ConditionEvaluator { get; }
 
     void AddProperty(IProperty property);
-    void CancelStateUpdate();
 }

--- a/src/DialogFramework.Application.Tests/RequestHandlers/StartRequestHandlerTests.cs
+++ b/src/DialogFramework.Application.Tests/RequestHandlers/StartRequestHandlerTests.cs
@@ -64,7 +64,7 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var dialog = DialogFixture.Create(definition.Metadata);
         var factory = new DialogFactoryFixture(_ => true, _ => dialog);
         ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
-                       .Returns(Result<IDialogDefinition>.Success(definition));
+                    .Returns(Result<IDialogDefinition>.Success(definition));
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act
@@ -89,7 +89,8 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
                                                dialog => Equals(dialog.Metadata.Id, dialogDefinition1.Metadata.Id)
                                                    ? DialogFixture.Create(dialogDefinition1.Metadata)
                                                    : DialogFixture.Create(dialogDefinition2.Metadata));
-        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Returns<IDialogDefinitionIdentifier>(identifier =>
+        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
+                    .Returns<IDialogDefinitionIdentifier>(identifier =>
         {
             if (Equals(identifier.Id, dialogDefinition1.Metadata.Id) && Equals(identifier.Version, dialogDefinition1.Metadata.Version)) return Result<IDialogDefinition>.Success(dialogDefinition1);
             if (Equals(identifier.Id, dialogDefinition2.Metadata.Id) && Equals(identifier.Version, dialogDefinition2.Metadata.Version)) return Result<IDialogDefinition>.Success(dialogDefinition2);
@@ -115,7 +116,8 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var dialogDefinition = DialogDefinitionFixture.CreateSingleStepDefinitionBuilder();
         var factory = new DialogFactoryFixture(d => Equals(d.Metadata.Id, dialogDefinition.Metadata.Id),
                                                _ => DialogFixture.Create(dialogDefinition.Metadata));
-        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Returns(Result<IDialogDefinition>.Success(dialogDefinition));
+        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
+                    .Returns(Result<IDialogDefinition>.Success(dialogDefinition));
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act
@@ -156,7 +158,7 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var factory = new DialogFactoryFixture(d => Equals(d.Metadata.Id, dialogDefinition.Metadata.Id),
                                                _ => DialogFixture.Create(dialogDefinition.Metadata));
         ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
-                     .Returns(Result<IDialogDefinition>.NotFound());
+                    .Returns(Result<IDialogDefinition>.NotFound());
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act
@@ -177,7 +179,8 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var dialogDefinition = DialogDefinitionFixture.CreateBuilder().Build();
         var factory = new DialogFactoryFixture(d => Equals(d.Metadata.Id, dialogDefinition.Metadata.Id),
                                                _ => DialogFixture.Create(dialogDefinition.Metadata));
-        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Throws(new InvalidOperationException("Kaboom"));
+        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
+                    .Throws(new InvalidOperationException("Kaboom"));
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act
@@ -214,7 +217,8 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var dialogDefinition = DialogDefinitionFixture.CreateDialogDefinitionWithDecisionPartThatReturnsErrorDialogPart();
         var factory = new DialogFactoryFixture(d => Equals(d.Metadata.Id, dialogDefinition.Metadata.Id),
                                                _ => DialogFixture.Create(dialogDefinition.Metadata));
-        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Returns(Result<IDialogDefinition>.Success(dialogDefinition));
+        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
+                    .Returns(Result<IDialogDefinition>.Success(dialogDefinition));
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act
@@ -245,7 +249,8 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
             .Build();
         var factory = new DialogFactoryFixture(d => Equals(d.Metadata.Id, dialogDefinition.Metadata.Id),
                                                _ => DialogFixture.Create(dialogDefinition.Metadata));
-        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Returns(Result<IDialogDefinition>.Success(dialogDefinition));
+        ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>()))
+                    .Returns(Result<IDialogDefinition>.Success(dialogDefinition));
         var sut = new StartRequestHandler(factory, ProviderMock.Object, ConditionEvaluatorMock.Object, LoggerMock.Object);
 
         // Act

--- a/src/DialogFramework.Application.Tests/RequestHandlers/StartRequestHandlerTests.cs
+++ b/src/DialogFramework.Application.Tests/RequestHandlers/StartRequestHandlerTests.cs
@@ -38,7 +38,7 @@ public class StartRequestHandlerTests : RequestHandlerTestBase
         var dialogDefinitionMock = new Mock<IDialogDefinition>();
         dialogDefinitionMock.SetupGet(x => x.Metadata).Returns(dialogMetadataMock.Object);
         dialogDefinitionMock.SetupGet(x => x.ErrorPart).Returns(errorPartMock.Object);
-        dialogDefinitionMock.Setup(x => x.GetFirstPart(It.IsAny<IDialog>(), It.IsAny<IConditionEvaluator>())).Returns(Result<IDialogPart>.Success(dialogPartMock.Object));
+        dialogDefinitionMock.Setup(x => x.GetFirstPart()).Returns(Result<IDialogPart>.Success(dialogPartMock.Object));
         var factory = new DialogFactoryFixture(_ => true,
                                                _ => DialogFixture.Create("Id", dialogDefinitionMock.Object.Metadata, dialogPartMock.Object));
         ProviderMock.Setup(x => x.GetDialogDefinition(It.IsAny<IDialogDefinitionIdentifier>())).Returns(Result<IDialogDefinition>.Success(dialogDefinitionMock.Object));

--- a/src/DialogFramework.Domain.TestData/DialogDefinitionFixture.cs
+++ b/src/DialogFramework.Domain.TestData/DialogDefinitionFixture.cs
@@ -176,9 +176,9 @@ public static class DialogDefinitionFixture
                 "Message" => Result<IDialogPart>.Success(messagePartMock.Object),
                 _ => Result<IDialogPart>.NotFound()
             });
-        mock.Setup(x => x.GetNextPart(It.IsAny<IDialog>(), It.IsAny<IConditionEvaluator>(), It.IsAny<IEnumerable<IDialogPartResultAnswer>>()))
+        mock.Setup(x => x.GetNextPart(It.IsAny<IDialog>(), It.IsAny<IEnumerable<IDialogPartResultAnswer>>()))
             .Returns(Result<IDialogPart>.Success(completedPartMock.Object));
-        mock.Setup(x => x.GetFirstPart(It.IsAny<IDialog>(), It.IsAny<IConditionEvaluator>()))
+        mock.Setup(x => x.GetFirstPart())
             .Returns(Result<IDialogPart>.Success(messagePartMock.Object));
         mock.Setup(x => x.CanNavigateTo(It.IsAny<IDialogPartIdentifier>(), It.IsAny<IDialogPartIdentifier>(), It.IsAny<IEnumerable<IDialogPartResult>>()))
             .Returns(Result.Success());

--- a/src/DialogFramework.Domain.TestData/DialogPartFixture.cs
+++ b/src/DialogFramework.Domain.TestData/DialogPartFixture.cs
@@ -29,14 +29,10 @@ public static class DialogPartFixture
         public void BeforeNavigate(IBeforeNavigateArguments args)
         {
             // Method intentionally left empty.
+            throw new NotImplementedException();
         }
 
         public IDialogPartBuilder CreateBuilder() => new ThrowingDialogPartBuilder(this);
-
-        public IDialogPartIdentifier GetNextPartId(IDialog dialog)
-        {
-            throw new NotImplementedException();
-        }
 
         public DialogState GetState() => DialogState.InProgress;
 

--- a/src/DialogFramework.Domain.TestData/DialogPartFixture.cs
+++ b/src/DialogFramework.Domain.TestData/DialogPartFixture.cs
@@ -5,8 +5,8 @@ public static class DialogPartFixture
 {
     public static IDialogPart CreateErrorThrowingDialogPart() => new ThrowingDialogPart();
     public static IDialogPartBuilder CreateErrorThrowingDialogPartBuilder() => new ThrowingDialogPartBuilder(CreateErrorThrowingDialogPart());
-    public static AddPropertiesDialogPart CreateAddPropertiesDialogPart(Action<IAfterNavigateArguments> afterNavigateCallback, Action<IBeforeNavigateArguments> beforeNavigateCallback, DialogState state = DialogState.InProgress) => new AddPropertiesDialogPart(afterNavigateCallback, beforeNavigateCallback, state);
-    public static AddPropertiesDialogPartBuilder CreateAddPropertiesDialogPartBuilder(Action<IAfterNavigateArguments> afterNavigateCallback, Action<IBeforeNavigateArguments> beforeNavigateCallback) => new AddPropertiesDialogPartBuilder(CreateAddPropertiesDialogPart(afterNavigateCallback, beforeNavigateCallback));
+    public static AddPropertiesDialogPart CreateAddPropertiesDialogPart(Func<IAfterNavigateArguments, Result<IDialogPart>?> afterNavigateCallback, Func<IBeforeNavigateArguments, Result<IDialogPart>?> beforeNavigateCallback, DialogState state = DialogState.InProgress) => new AddPropertiesDialogPart(afterNavigateCallback, beforeNavigateCallback, state);
+    public static AddPropertiesDialogPartBuilder CreateAddPropertiesDialogPartBuilder(Func<IAfterNavigateArguments, Result<IDialogPart>?> afterNavigateCallback, Func<IBeforeNavigateArguments, Result<IDialogPart>?> beforeNavigateCallback) => new AddPropertiesDialogPartBuilder(CreateAddPropertiesDialogPart(afterNavigateCallback, beforeNavigateCallback));
 
     [ExcludeFromCodeCoverage]
     private sealed class ThrowingDialogPartBuilder : IDialogPartBuilder
@@ -21,16 +21,11 @@ public static class DialogPartFixture
     {
         public IDialogPartIdentifier Id => new DialogPartIdentifier(nameof(ThrowingDialogPart));
 
-        public void AfterNavigate(IAfterNavigateArguments args)
-        {
-            // Method intentionally left empty.
-        }
+        public Result<IDialogPart>? AfterNavigate(IAfterNavigateArguments args)
+            => default;
 
-        public void BeforeNavigate(IBeforeNavigateArguments args)
-        {
-            // Method intentionally left empty.
-            throw new NotImplementedException();
-        }
+        public Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args)
+            => throw new NotImplementedException();
 
         public IDialogPartBuilder CreateBuilder() => new ThrowingDialogPartBuilder(this);
 
@@ -43,10 +38,10 @@ public static class DialogPartFixture
     {
         public IDialogPartIdentifier Id { get; }
         private DialogState State { get; }
-        private readonly Action<IAfterNavigateArguments> AfterNavigateCallback;
-        private readonly Action<IBeforeNavigateArguments> BeforeNavigateCallback;
+        private readonly Func<IAfterNavigateArguments, Result<IDialogPart>?> AfterNavigateCallback;
+        private readonly Func<IBeforeNavigateArguments, Result<IDialogPart>?> BeforeNavigateCallback;
 
-        public AddPropertiesDialogPart(Action<IAfterNavigateArguments> afterNavigateCallback, Action<IBeforeNavigateArguments> beforeNavigateCallback, DialogState state)
+        public AddPropertiesDialogPart(Func<IAfterNavigateArguments, Result<IDialogPart>?> afterNavigateCallback, Func<IBeforeNavigateArguments, Result<IDialogPart>?> beforeNavigateCallback, DialogState state)
         {
             Id = new DialogPartIdentifier(string.Concat(nameof(AddPropertiesDialogPart), DateTime.Now.Ticks.ToString()));
             State = state;
@@ -54,9 +49,9 @@ public static class DialogPartFixture
             BeforeNavigateCallback = beforeNavigateCallback;
         }
 
-        public void AfterNavigate(IAfterNavigateArguments args) => AfterNavigateCallback(args);
+        public Result<IDialogPart>? AfterNavigate(IAfterNavigateArguments args) => AfterNavigateCallback(args);
 
-        public void BeforeNavigate(IBeforeNavigateArguments args) => BeforeNavigateCallback(args);
+        public Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args) => BeforeNavigateCallback(args);
 
         public IDialogPartBuilder CreateBuilder() => new AddPropertiesDialogPartBuilder(this);
 

--- a/src/DialogFramework.Domain.Tests/AfterNavigateArgumentsTests.cs
+++ b/src/DialogFramework.Domain.Tests/AfterNavigateArgumentsTests.cs
@@ -9,23 +9,6 @@ public class AfterNavigateArgumentsTests
     }
 
     [Fact]
-    public void Can_Set_Result()
-    {
-        // Arrange
-        var dialogMock = new Mock<IDialog>();
-        var definitionMock = new Mock<IDialogDefinition>();
-        var conditionEvaluatorMock = new Mock<IConditionEvaluator>();
-        var sut = new AfterNavigateArguments(dialogMock.Object, definitionMock.Object, conditionEvaluatorMock.Object, DialogAction.Continue);
-        var result = Result.Error("Kaboom");
-
-        // Act
-        sut.Result = result;
-
-        // Assert
-        sut.Result.Should().BeEquivalentTo(result);
-    }
-
-    [Fact]
     public void Can_Add_Property()
     {
         // Arrange

--- a/src/DialogFramework.Domain.Tests/BeforeNavigateArgumentsTests.cs
+++ b/src/DialogFramework.Domain.Tests/BeforeNavigateArgumentsTests.cs
@@ -7,20 +7,4 @@ public class BeforeNavigateArgumentsTests
     {
         TestHelpers.ConstructorMustThrowArgumentNullException(typeof(BeforeNavigateArguments), parameterPredicate: pi => pi.Name != "currentGroupId" && pi.Name != "errorMessage");
     }
-
-    [Fact]
-    public void Can_Cancel_StateUpdate()
-    {
-        // Arrange
-        var dialogMock = new Mock<IDialog>();
-        var definitionMock = new Mock<IDialogDefinition>();
-        var conditionEvaluatorMock = new Mock<IConditionEvaluator>();
-        var sut = new BeforeNavigateArguments(dialogMock.Object, definitionMock.Object, conditionEvaluatorMock.Object, DialogAction.Continue);
-
-        // Act
-        sut.CancelStateUpdate();
-
-        // Assert
-        sut.UpdateState.Should().BeFalse();
-    }
 }

--- a/src/DialogFramework.Domain.Tests/DialogDefinitionTests.cs
+++ b/src/DialogFramework.Domain.Tests/DialogDefinitionTests.cs
@@ -2,13 +2,6 @@
 
 public class DialogDefinitionTests
 {
-    private readonly Mock<IConditionEvaluator> _conditionEvaluatorMock;
-
-    public DialogDefinitionTests()
-    {
-        _conditionEvaluatorMock = new Mock<IConditionEvaluator>();
-    }
-
     [Fact]
     public void ReplaceAnswers_Replaces_Previous_Anwers_From_Same_Question()
     {
@@ -119,7 +112,7 @@ public class DialogDefinitionTests
             .Build();
 
         // Act
-        var actual = sut.CanNavigateTo(sut.CompletedPart.Id, sut.Parts.First().Id, new[] { partResult } );
+        var actual = sut.CanNavigateTo(sut.CompletedPart.Id, sut.Parts.First().Id, new[] { partResult });
 
         // Assert
         actual.IsSuccessful().Should().BeTrue();
@@ -143,24 +136,22 @@ public class DialogDefinitionTests
     {
         // Arrange
         var sut = DialogDefinitionFixture.CreateBuilderBase().Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
 
         // Act
-        var result = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
+        var result = sut.GetFirstPart();
 
         // Assert
         result.Value.Should().BeSameAs(sut.CompletedPart);
     }
 
     [Fact]
-    public void GetFirstPart_Returns_First_Part_When_It_Is_A_Static_DialogPart()
+    public void GetFirstPart_Returns_First_Part_When_It_Is_Available()
     {
         // Arrange
         var sut = DialogDefinitionFixture.CreateBuilder().Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
 
         // Act
-        var actual = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
+        var actual = sut.GetFirstPart();
 
         // Assert
         actual.IsSuccessful().Should().BeTrue();
@@ -178,7 +169,7 @@ public class DialogDefinitionTests
             .Build();
 
         // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult } );
+        var result = sut.GetNextPart(dialog, new[] { partResult });
 
         // Assert
         result.IsSuccessful().Should().BeFalse();
@@ -198,7 +189,7 @@ public class DialogDefinitionTests
             .Build();
 
         // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult });
+        var result = sut.GetNextPart(dialog, new[] { partResult });
 
         // Assert
         result.IsSuccessful().Should().BeFalse();
@@ -207,7 +198,7 @@ public class DialogDefinitionTests
     }
 
     [Fact]
-    public void GetNextPart_Returns_Next_Part_When_Validation_Succeeds_And_Next_Part_Is_A_Static_DialogPart()
+    public void GetNextPart_Returns_Next_Part_When_Validation_Succeeds_And_Next_Part_Is_Available()
     {
         var sut = DialogDefinitionFixture.CreateBuilder().Build();
         var dialog = DialogFixture.Create(sut.Metadata, sut.Parts.First().Id);
@@ -216,7 +207,7 @@ public class DialogDefinitionTests
             .Build();
 
         // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult } );
+        var result = sut.GetNextPart(dialog, new[] { partResult });
 
         // Assert
         result.IsSuccessful().Should().BeTrue();
@@ -237,7 +228,7 @@ public class DialogDefinitionTests
             .Build();
 
         // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult });
+        var result = sut.GetNextPart(dialog, new[] { partResult });
 
         // Assert
         result.IsSuccessful().Should().BeTrue();

--- a/src/DialogFramework.Domain.Tests/DialogDefinitionTests.cs
+++ b/src/DialogFramework.Domain.Tests/DialogDefinitionTests.cs
@@ -139,46 +139,6 @@ public class DialogDefinitionTests
     }
 
     [Fact]
-    public void GetFirstPart_Returns_NotFound_When_Decision_Part_Returns_An_Unknown_PartId()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilderBase()
-            .AddParts(new DecisionDialogPartBuilder()
-                .WithId(new DialogPartIdentifierBuilder())
-                .WithDefaultNextPartId(new DialogPartIdentifierBuilder().WithValue("non existing id")))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
-
-        // Act
-        var result = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
-
-        // Assert
-        result.IsSuccessful().Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.NotFound);
-        result.ErrorMessage.Should().Be("Dialog does not have a part with id [DialogPartIdentifier { Value = non existing id }]");
-    }
-
-    [Fact]
-    public void GetFirstPart_Returns_NotFound_When_Navigation_Part_Returns_An_Unknown_PartId()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilderBase()
-            .AddParts(new NavigationDialogPartBuilder()
-                .WithId(new DialogPartIdentifierBuilder())
-                .WithNavigateToId(new DialogPartIdentifierBuilder().WithValue("non existing id")))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
-
-        // Act
-        var result = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
-
-        // Assert
-        result.IsSuccessful().Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.NotFound);
-        result.ErrorMessage.Should().Be("Dialog does not have a part with id [DialogPartIdentifier { Value = non existing id }]");
-    }
-
-    [Fact]
     public void GetFirstPart_Returns_CompletedPart_When_No_Other_Parts_Are_Available()
     {
         // Arrange
@@ -205,40 +165,6 @@ public class DialogDefinitionTests
         // Assert
         actual.IsSuccessful().Should().BeTrue();
         actual.Value.Should().BeEquivalentTo(sut.Parts.First());
-    }
-
-    [Fact]
-    public void GetFirstPart_Returns_Processed_Decision_From_First_Part_When_It_Is_A_DecisionDialogPart()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilder()
-            .With(x => x.Parts.Insert(0, new DecisionDialogPartBuilder().WithId(new DialogPartIdentifierBuilder()).WithDefaultNextPartId(x.Parts.OfType<MessageDialogPartBuilder>().First().Id)))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
-
-        // Act
-        var actual = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
-
-        // Assert
-        actual.IsSuccessful().Should().BeTrue();
-        actual.Value.Should().BeEquivalentTo(sut.Parts.OfType<IMessageDialogPart>().First());
-    }
-
-    [Fact]
-    public void GetFirstPart_Returns_Processed_Navigation_From_First_Part_When_It_Is_A_NavigationDialogPart()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilder()
-            .With(x => x.Parts.Insert(0, new NavigationDialogPartBuilder().WithId(new DialogPartIdentifierBuilder()).WithNavigateToId(x.Parts.OfType<MessageDialogPartBuilder>().First().Id)))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata);
-
-        // Act
-        var actual = sut.GetFirstPart(dialog, _conditionEvaluatorMock.Object);
-
-        // Assert
-        actual.IsSuccessful().Should().BeTrue();
-        actual.Value.Should().BeEquivalentTo(sut.Parts.OfType<IMessageDialogPart>().First());
     }
 
     [Fact]
@@ -291,69 +217,6 @@ public class DialogDefinitionTests
 
         // Act
         var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult } );
-
-        // Assert
-        result.IsSuccessful().Should().BeTrue();
-        result.Value!.Id.Should().BeEquivalentTo(sut.Parts.OfType<IMessageDialogPart>().First().Id); //second part
-        result.ValidationErrors.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void GetNextPart_Returns_Processed_Decision_From_Next_Part_When_Validation_Succeeds_And_Next_Part_Is_A_DecisionDialogPart_That_Returns_Success()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilder()
-            .With(x => x.Parts.Insert(1, new DecisionDialogPartBuilder().WithId(new DialogPartIdentifierBuilder()).WithDefaultNextPartId(x.Parts.OfType<MessageDialogPartBuilder>().First().Id)))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata, sut.Parts.First().Id);
-        var partResult = new DialogPartResultAnswerBuilder()
-            .WithResultId(new DialogPartResultIdentifierBuilder())
-            .Build();
-
-        // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult });
-
-        // Assert
-        result.IsSuccessful().Should().BeTrue();
-        result.Value!.Id.Should().BeEquivalentTo(sut.Parts.OfType<IMessageDialogPart>().First().Id); //second part
-        result.ValidationErrors.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void GetNextPart_Returns_Error_When_Validation_Succeeds_And_Next_Part_Is_A_DecisionDialogPart_That_Returns_An_Error()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilder()
-            .With(x => x.Parts.Insert(1, new DecisionDialogPartBuilder().WithId(new DialogPartIdentifierBuilder())))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata, sut.Parts.First().Id);
-        var partResult = new DialogPartResultAnswerBuilder()
-            .WithResultId(new DialogPartResultIdentifierBuilder())
-            .Build();
-
-        // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult });
-
-        // Assert
-        result.IsSuccessful().Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.Error);
-        result.ErrorMessage.Should().Be("No next dialog part supplied");
-    }
-
-    [Fact]
-    public void GetNextPart_Returns_Processed_Decision_From_Next_Part_When_Validation_Succeeds_And_Next_Part_Is_A_NavigationDialogPart()
-    {
-        // Arrange
-        var sut = DialogDefinitionFixture.CreateBuilder()
-            .With(x => x.Parts.Insert(1, new NavigationDialogPartBuilder().WithId(new DialogPartIdentifierBuilder()).WithNavigateToId(x.Parts.OfType<MessageDialogPartBuilder>().First().Id)))
-            .Build();
-        var dialog = DialogFixture.Create(sut.Metadata, sut.Parts.First().Id);
-        var partResult = new DialogPartResultAnswerBuilder()
-            .WithResultId(new DialogPartResultIdentifierBuilder())
-            .Build();
-
-        // Act
-        var result = sut.GetNextPart(dialog, _conditionEvaluatorMock.Object, new[] { partResult });
 
         // Assert
         result.IsSuccessful().Should().BeTrue();

--- a/src/DialogFramework.Domain.Tests/DialogTests.cs
+++ b/src/DialogFramework.Domain.Tests/DialogTests.cs
@@ -207,16 +207,11 @@ public class DialogTests
     }
 
     [Fact]
-    public void Start_Returns_Error_When_First_Part_Is_Dynamic_And_Gives_Error()
+    public void Start_Returns_Error_When_First_Part_Is_DecisionPart_And_DecisionPart_Returns_Error()
     {
         // Arrange
-        var dialogDefinition = DialogDefinitionFixture
-            .CreateBuilderBase()
-            .AddParts(new NavigationDialogPartBuilder()
-                .WithNavigateToId(new DialogPartIdentifierBuilder().WithValue("Non existing id"))
-                .WithId(new DialogPartIdentifierBuilder()))
-            .WithMetadata(new DialogMetadataBuilder()
-                .WithId("Id"))
+        var dialogDefinition = DialogDefinitionFixture.CreateBuilderBase()
+            .AddParts(new DecisionDialogPartBuilder().WithId(new DialogPartIdentifierBuilder().WithValue("Id")))
             .Build();
         var sut = DialogFixture.Create(dialogDefinition.Metadata);
 
@@ -226,7 +221,47 @@ public class DialogTests
         // Assert
         result.IsSuccessful().Should().BeFalse();
         result.Status.Should().Be(ResultStatus.Error);
-        result.ErrorMessage.Should().Be("Dialog does not have a part with id [DialogPartIdentifier { Value = Non existing id }]");
+        result.ErrorMessage.Should().Be("No next dialog part supplied");
+    }
+
+    [Fact]
+    public void Start_Returns_Error_When_First_Part_Is_DecisionPart_And_DecisionPart_Returns_NonExisting_Part()
+    {
+        // Arrange
+        var dialogDefinition = DialogDefinitionFixture.CreateBuilderBase()
+            .AddParts(new DecisionDialogPartBuilder()
+                .WithId(new DialogPartIdentifierBuilder().WithValue("Id"))
+                .WithDefaultNextPartId(new DialogPartIdentifierBuilder().WithValue("NonExistingId")))
+            .Build();
+        var sut = DialogFixture.Create(dialogDefinition.Metadata);
+
+        // Act
+        var result = sut.Start(dialogDefinition, _conditionEvaluatorMock.Object);
+
+        // Assert
+        result.IsSuccessful().Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.ErrorMessage.Should().Be("Dialog does not have a part with id [DialogPartIdentifier { Value = NonExistingId }]");
+    }
+
+    [Fact]
+    public void Start_Returns_Error_When_First_Part_Is_NavigationPart_And_NavigationPart_Returns_NonExisting_Part()
+    {
+        // Arrange
+        var dialogDefinition = DialogDefinitionFixture.CreateBuilderBase()
+            .AddParts(new NavigationDialogPartBuilder()
+                .WithId(new DialogPartIdentifierBuilder().WithValue("Id"))
+                .WithNavigateToId(new DialogPartIdentifierBuilder().WithValue("NonExistingId")))
+            .Build();
+        var sut = DialogFixture.Create(dialogDefinition.Metadata);
+
+        // Act
+        var result = sut.Start(dialogDefinition, _conditionEvaluatorMock.Object);
+
+        // Assert
+        result.IsSuccessful().Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.ErrorMessage.Should().Be("Dialog does not have a part with id [DialogPartIdentifier { Value = NonExistingId }]");
     }
 
     [Fact]

--- a/src/DialogFramework.Domain/Dialog.cs
+++ b/src/DialogFramework.Domain/Dialog.cs
@@ -54,7 +54,7 @@ public partial record Dialog
         (
             definition,
             evaluator,
-            definition.GetNextPart(this, evaluator, results),
+            definition.GetNextPart(this, results),
             DialogAction.Continue,
             partResult =>
             {
@@ -117,7 +117,7 @@ public partial record Dialog
         (
             definition,
             evaluator,
-            definition.GetFirstPart(this, evaluator),
+            definition.GetFirstPart(),
             DialogAction.Start,
             partResult =>
             {
@@ -130,11 +130,7 @@ public partial record Dialog
             },
             partResult =>
             {
-                if (!partResult.IsSuccessful())
-                {
-                    return Result.Error(partResult.ErrorMessage.WhenNullOrEmpty("There was an error getting the first part"));
-                }
-                else if (partResult.Value is IRedirectDialogPart redirectDialogPart)
+                if (partResult.Value is IRedirectDialogPart redirectDialogPart)
                 {
                     return Result<IDialogDefinitionIdentifier>.Redirect(redirectDialogPart.RedirectDialogMetadata);
                 }

--- a/src/DialogFramework.Domain/DialogDefinition.cs
+++ b/src/DialogFramework.Domain/DialogDefinition.cs
@@ -48,12 +48,10 @@ public partial record DialogDefinition : IValidatableObject
         return Result.Success();
     }
 
-    public Result<IDialogPart> GetFirstPart(IDialog dialog, IConditionEvaluator evaluator)
+    public Result<IDialogPart> GetFirstPart()
         => Result<IDialogPart>.Success(Parts.FirstOrDefault() ?? CompletedPart);
 
-    public Result<IDialogPart> GetNextPart(IDialog dialog,
-                                           IConditionEvaluator evaluator,
-                                           IEnumerable<IDialogPartResultAnswer> results)
+    public Result<IDialogPart> GetNextPart(IDialog dialog, IEnumerable<IDialogPartResultAnswer> results)
     {
         // first perform validation
         var currentPartResult = GetPartById(dialog.CurrentPartId);

--- a/src/DialogFramework.Domain/DialogParts/DecisionDialogPart.cs
+++ b/src/DialogFramework.Domain/DialogParts/DecisionDialogPart.cs
@@ -2,31 +2,18 @@
 
 public partial record DecisionDialogPart : DialogPartBase
 {
-    public override void BeforeNavigate(IBeforeNavigateArguments args)
+    public override Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args)
     {
-        args.CancelStateUpdate();
-
         var partId = Decisions.FirstOrDefault(x => args.ConditionEvaluator.Evaluate(args, x.Conditions))?.NextPartId
             ?? DefaultNextPartId;
 
         if (partId == null)
         {
-            args.Result = Result<IDialogPart>.Error("No next dialog part supplied");
+            return Result<IDialogPart>.Error("No next dialog part supplied");
         }
         else
         {
-            var partByIdResult = args.DialogDefinition.GetPartById(partId);
-            if (!partByIdResult.IsSuccessful())
-            {
-                args.Result = partByIdResult;
-            }
-            else
-            {
-                var part = partByIdResult.GetValueOrThrow();
-                args.CurrentPartId = part.Id;
-                args.CurrentGroupId = part.GetGroupId();
-                args.CurrentState = part.GetState();
-            }
+            return args.DialogDefinition.GetPartById(partId);
         }
     }
 

--- a/src/DialogFramework.Domain/DialogParts/DialogPartBase.cs
+++ b/src/DialogFramework.Domain/DialogParts/DialogPartBase.cs
@@ -2,13 +2,9 @@
 
 public abstract record DialogPartBase
 {
-    public virtual void AfterNavigate(IAfterNavigateArguments args)
-    {
-        // Method intentionally left empty.
-    }
+    public virtual Result<IDialogPart>? AfterNavigate(IAfterNavigateArguments args)
+        => default;
 
-    public virtual void BeforeNavigate(IBeforeNavigateArguments args)
-    {
-        // Method intentionally left empty.
-    }
+    public virtual Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args)
+        => default;
 }

--- a/src/DialogFramework.Domain/DialogParts/NavigationDialogPart.cs
+++ b/src/DialogFramework.Domain/DialogParts/NavigationDialogPart.cs
@@ -6,21 +6,6 @@ public partial record NavigationDialogPart : DialogPartBase
     public IDialogPartBuilder CreateBuilder() => new NavigationDialogPartBuilder(this);
     public bool SupportsReset() => false;
 
-    public override void BeforeNavigate(IBeforeNavigateArguments args)
-    {
-        args.CancelStateUpdate();
-
-        var partByIdResult = args.DialogDefinition.GetPartById(NavigateToId);
-        if (!partByIdResult.IsSuccessful())
-        {
-            args.Result = partByIdResult;
-        }
-        else
-        {
-            var part = partByIdResult.GetValueOrThrow();
-            args.CurrentPartId = part.Id;
-            args.CurrentGroupId = part.GetGroupId();
-            args.CurrentState = part.GetState();
-        }
-    }
+    public override Result<IDialogPart>? BeforeNavigate(IBeforeNavigateArguments args)
+        => args.DialogDefinition.GetPartById(NavigateToId);
 }

--- a/src/DialogFramework.Domain/DialogParts/NavigationDialogPart.cs
+++ b/src/DialogFramework.Domain/DialogParts/NavigationDialogPart.cs
@@ -2,8 +2,25 @@
 
 public partial record NavigationDialogPart : DialogPartBase
 {
-    public IDialogPartIdentifier GetNextPartId(IDialog dialog) => NavigateToId;
     public DialogState GetState() => DialogState.InProgress;
     public IDialogPartBuilder CreateBuilder() => new NavigationDialogPartBuilder(this);
     public bool SupportsReset() => false;
+
+    public override void BeforeNavigate(IBeforeNavigateArguments args)
+    {
+        args.CancelStateUpdate();
+
+        var partByIdResult = args.DialogDefinition.GetPartById(NavigateToId);
+        if (!partByIdResult.IsSuccessful())
+        {
+            args.Result = partByIdResult;
+        }
+        else
+        {
+            var part = partByIdResult.GetValueOrThrow();
+            args.CurrentPartId = part.Id;
+            args.CurrentGroupId = part.GetGroupId();
+            args.CurrentState = part.GetState();
+        }
+    }
 }

--- a/src/DialogFramework.Domain/NavigateArgumentsBase.cs
+++ b/src/DialogFramework.Domain/NavigateArgumentsBase.cs
@@ -3,13 +3,11 @@
 public abstract record NavigateArgumentsBase : INavigateArguments
 {
     public IDialogIdentifier CurrentDialogId { get; }
-    public IDialogDefinitionIdentifier CurrentDialogIdentifier { get; set; }
-    public IDialogPartIdentifier CurrentPartId { get; set; }
-    public IDialogPartGroupIdentifier? CurrentGroupId { get; set; }
-    public DialogState CurrentState { get; set; }
-    public string? ErrorMessage { get; set; }
-    public Result? Result { get; set; }
-    public bool UpdateState { get; private set; } = true;
+    public IDialogDefinitionIdentifier CurrentDialogIdentifier { get; }
+    public IDialogPartIdentifier CurrentPartId { get; }
+    public IDialogPartGroupIdentifier? CurrentGroupId { get; }
+    public DialogState CurrentState { get; }
+    public string? ErrorMessage { get; }
 
     public DialogAction Action { get; }
     public IDialogDefinition DialogDefinition { get; }
@@ -46,7 +44,4 @@ public abstract record NavigateArgumentsBase : INavigateArguments
 
     public void AddProperty(IProperty property)
         => Dialog.AddProperty(property);
-
-    public void CancelStateUpdate()
-        => UpdateState = false;
 }


### PR DESCRIPTION
Refactor Decision and Navigation dialog parts, so they are generic.

Attempt to move the code from these dialog parts to Before/After navigate methods, this fixes open/closed principle violation.